### PR TITLE
Add support for php 8.0

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,9 +1,0 @@
-<?php
-declare(strict_types=1);
-
-include __DIR__ . '/vendor/autoload.php';
-
-return Paysera\PhpCsFixerConfig\Config\PayseraConventionsConfig::create()
-    ->setDefaultFinder(['src', 'tests'], [])
-    ->setRiskyRules()
-;

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,3 @@ before_script:
 
 script:
     - bin/phpunit
-#    - if [[ "$WITH_CS" == "true" ]]; then bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection "${COMMIT_SCA_FILES[@]}"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
         env: COMPOSER_ARGS=""
       - php: 7.4
         env: COMPOSER_ARGS=""
+      - php: 8.0
+        env: COMPOSER_ARGS=""
 
       - php: 7.0
         env: COMPOSER_ARGS="--prefer-lowest"
@@ -24,6 +26,8 @@ matrix:
       - php: 7.2
         env: COMPOSER_ARGS="--prefer-lowest"
       - php: 7.4
+        env: COMPOSER_ARGS="--prefer-lowest"
+      - php: 8.0
         env: COMPOSER_ARGS="--prefer-lowest"
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ before_script:
 
 script:
     - bin/phpunit
-    - if [[ "$WITH_CS" == "true" ]]; then bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection "${COMMIT_SCA_FILES[@]}"; fi
+#    - if [[ "$WITH_CS" == "true" ]]; then bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection "${COMMIT_SCA_FILES[@]}"; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Temporary removed `paysera/lib-php-cs-fixer-config` due to incompatibility with php 8.0
 - Temporary removed `friendsofphp/php-cs-fixer` due to `paysera/lib-php-cs-fixer-config` incompatibility
-- Temporary commented `cs-fixer` script from `.travis.yml`
+- Temporary removed `cs-fixer` script from `.travis.yml`
 
 ## [1.2.2] - 2022-01-20
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2022-03-11
+### Added
+- Support for `"php": "^8.0"`
+- Support for `"phpunit/phpunit"": "^8.5"` and `"^9.5"`
+### Removed
+- Temporary removed `paysera/lib-php-cs-fixer-config` due to incompatibility with php 8.0
+- Temporary removed `friendsofphp/php-cs-fixer` due to `paysera/lib-php-cs-fixer-config` incompatibility
+- Temporary commented `cs-fixer` script from `.travis.yml`
+
 ## [1.2.2] - 2022-01-20
 ### Removed
 - `internal` tag from `CompilerPassProviderInterface`, `CompositeConfigurator`, `ConfiguratorInterface`, 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.0] - 2022-03-11
 ### Added
 - Support for `"php": "^8.0"`
-- Support for `"phpunit/phpunit"": "^8.5"` and `"^9.5"`
+- Support for `"phpunit/phpunit"": "^8.0"` and `"^9.0"`
 ### Removed
 - Temporary removed `paysera/lib-php-cs-fixer-config` due to incompatibility with php 8.0
 - Temporary removed `friendsofphp/php-cs-fixer` due to `paysera/lib-php-cs-fixer-config` incompatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0] - 2022-03-11
+## 1.3.0
 ### Added
 - Support for `"php": "^8.0"`
 - Support for `"phpunit/phpunit"": "^8.0"` and `"^9.0"`
@@ -13,20 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Temporary removed `friendsofphp/php-cs-fixer` due to `paysera/lib-php-cs-fixer-config` incompatibility
 - Temporary removed `cs-fixer` script from `.travis.yml`
 
-## [1.2.2] - 2022-01-20
+## 1.2.2
 ### Removed
 - `internal` tag from `CompilerPassProviderInterface`, `CompositeConfigurator`, `ConfiguratorInterface`, 
 `ConfiguratorLoader`, `DefinitionsConfigurator`
 
-## [1.2.1] - 2020-12-14
+## 1.2.1
 ### Remove
 - Remove return types to avoid breaking changes;
 
-## [1.2.0] - 2020-12-11
+## 1.2.0
 ### Added
 - Added `"symfony/dependency-injection": "^5.0"` and `"symfony/config": "^5.0"` dependencies for Symfony 5 support;
 
-## [1.1.0]
+## 1.1.0
 ### Added
 - `AddTaggedCompilerPass` support for parameters with default values (associative array);
 - `AddTaggedCompilerPass` support for priorities;

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/config": "^2.3|^3.0|^4.0|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5 | ^8.5 | ^9.5"
+        "phpunit/phpunit": "^6.5 | ^8.0 | ^9.0"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -15,22 +15,18 @@
         }
     },
     "require": {
-        "php": "^7.0",
+        "php": "^7.0 | ^8.0",
         "symfony/dependency-injection": "^2.3|^3.0|^4.0|^5.0",
         "symfony/config": "^2.3|^3.0|^4.0|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
-        "paysera/lib-php-cs-fixer-config": "^2.0.0",
-        "friendsofphp/php-cs-fixer": "^2.11.1"
+        "phpunit/phpunit": "^6.5 | ^8.5 | ^9.5"
     },
     "config": {
         "bin-dir": "bin"
     },
     "scripts": {
         "phpunit": "phpunit",
-        "fix-cs": "php-cs-fixer fix",
-        "test-cs": "php-cs-fixer fix --dry-run -v",
         "test": ["@phpunit"]
     }
 }


### PR DESCRIPTION
**What was done**

- Added support for `php ^8.0`
- Added support for `phpunit/phpunit` versions `^8.5` and `^9.5`
- Removed `paysera/lib-php-cs-fixer-config` due to php version incompatibility
- Removed `friendsofphp/php-cs-fixer` due to php version incompatibility with `paysera/lib-php-cs-fixer-config`
